### PR TITLE
Add noopener to external links

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,7 +254,7 @@
               Certamente, o grau de
               <a
                 href="https://pt.wikipedia.org/wiki/Matura%C3%A7%C3%A3o"
-                target="_blank"
+                target="_blank" rel="noopener noreferrer"
                 class="text-blue-600 underline"
                 >maturação</a
               >
@@ -657,7 +657,7 @@
         © 2025 Todos os direitos reservados | Desenvolvido por
         <a
           href="https://github.com/mateusoliveiradev1"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
           class="underline"
           >Mateus</a
         >

--- a/pagina002.html
+++ b/pagina002.html
@@ -295,7 +295,7 @@
         © 2025 Todos os direitos reservados | Desenvolvido por
         <a
           href="https://github.com/mateusoliveiradev1"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
           class="underline"
           >Mateus</a
         >

--- a/pagina003.html
+++ b/pagina003.html
@@ -389,7 +389,7 @@
         © 2025 Todos os direitos reservados | Desenvolvido por
         <a
           href="https://github.com/mateusoliveiradev1"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
           class="underline"
         >
           Mateus Oliveira

--- a/pagina004.html
+++ b/pagina004.html
@@ -344,7 +344,7 @@
         © 2025 Todos os direitos reservados | Desenvolvido por
         <a
           href="https://github.com/mateusoliveiradev1"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
           class="underline"
           >Mateus Oliveira</a
         >

--- a/treinamento.html
+++ b/treinamento.html
@@ -778,7 +778,7 @@
         © 2025 Todos os direitos reservados | Desenvolvido por
         <a
           href="https://github.com/mateusoliveiradev1"
-          target="_blank"
+          target="_blank" rel="noopener noreferrer"
           class="underline"
           >Mateus</a
         >


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to links that open in new tabs

## Testing
- `grep -R "target=\"_blank\"" -n *.html`

------
https://chatgpt.com/codex/tasks/task_e_68534e8424f0832c8d2164a7c0a7a360