### PR TITLE
Improve theme initialization

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -16,10 +16,15 @@ function setTheme(theme) {
   }
 }
 
-if (localStorage.getItem('theme') === 'dark') {
-  setTheme('dark');
+const storedTheme = localStorage.getItem('theme');
+
+if (storedTheme === 'dark' || storedTheme === 'light') {
+  setTheme(storedTheme);
 } else {
-  setTheme('light');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  const initialTheme = prefersDark ? 'dark' : 'light';
+  localStorage.setItem('theme', initialTheme);
+  setTheme(initialTheme);
 }
 
 themeToggle.addEventListener('click', () => {


### PR DESCRIPTION
## Summary
- detect system color scheme when no theme is saved

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685353810d90832cb9e45b7b5266a853