### PR TITLE
Add CRUD API for courses and XP history

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,33 @@ npm start        # inicia o servidor em http://localhost:3000
 ```
 
 Os modelos disponíveis são **users**, **courses** e **xp_history**. Novas entradas podem ser adicionadas via requisições HTTP ou diretamente pelo SQLite.
+
+### Exemplo de uso da API
+
+Algumas rotas disponíveis quando o servidor está rodando em `http://localhost:3000`:
+
+```bash
+# listar cursos
+curl http://localhost:3000/courses
+
+# criar um curso
+curl -X POST http://localhost:3000/courses \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Curso de PEPS", "description": "Introdução ao método"}'
+
+# atualizar um curso
+curl -X PUT http://localhost:3000/courses/1 \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Curso atualizado", "description": "Descrição"}'
+
+# remover um curso
+curl -X DELETE http://localhost:3000/courses/1
+
+# adicionar XP para um usuário
+curl -X POST http://localhost:3000/xp-history \
+  -H "Content-Type: application/json" \
+  -d '{"user_id": 1, "course_id": 1, "xp": 50}'
+
+# histórico de XP do usuário
+curl http://localhost:3000/xp-history/user/1
+```

--- a/backend/index.js
+++ b/backend/index.js
@@ -27,5 +27,95 @@ app.get('/users', (req, res) => {
   });
 });
 
+// Courses routes
+app.post('/courses', (req, res) => {
+  const { title, description } = req.body;
+  courses.createCourse(title, description, (err, id) => {
+    if (err) return res.status(500).json({ error: err.message });
+    courses.getCourseById(id, (err2, row) => {
+      if (err2) return res.status(500).json({ error: err2.message });
+      res.json(row);
+    });
+  });
+});
+
+app.get('/courses', (req, res) => {
+  courses.listCourses((err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.get('/courses/:id', (req, res) => {
+  courses.getCourseById(req.params.id, (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(404).json({ error: 'Course not found' });
+    res.json(row);
+  });
+});
+
+app.put('/courses/:id', (req, res) => {
+  const { title, description } = req.body;
+  courses.updateCourse(req.params.id, title, description, err => {
+    if (err) return res.status(500).json({ error: err.message });
+    courses.getCourseById(req.params.id, (err2, row) => {
+      if (err2) return res.status(500).json({ error: err2.message });
+      res.json(row);
+    });
+  });
+});
+
+app.delete('/courses/:id', (req, res) => {
+  courses.deleteCourse(req.params.id, err => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true });
+  });
+});
+
+// XP history routes
+app.post('/xp-history', (req, res) => {
+  const { user_id, course_id, xp } = req.body;
+  xpHistory.addXP(user_id, course_id, xp, (err, id) => {
+    if (err) return res.status(500).json({ error: err.message });
+    xpHistory.getEntryById(id, (err2, row) => {
+      if (err2) return res.status(500).json({ error: err2.message });
+      res.json(row);
+    });
+  });
+});
+
+app.get('/xp-history/user/:userId', (req, res) => {
+  xpHistory.getHistoryByUser(req.params.userId, (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+app.get('/xp-history/:id', (req, res) => {
+  xpHistory.getEntryById(req.params.id, (err, row) => {
+    if (err) return res.status(500).json({ error: err.message });
+    if (!row) return res.status(404).json({ error: 'Entry not found' });
+    res.json(row);
+  });
+});
+
+app.put('/xp-history/:id', (req, res) => {
+  const { user_id, course_id, xp } = req.body;
+  xpHistory.updateEntry(req.params.id, user_id, course_id, xp, err => {
+    if (err) return res.status(500).json({ error: err.message });
+    xpHistory.getEntryById(req.params.id, (err2, row) => {
+      if (err2) return res.status(500).json({ error: err2.message });
+      res.json(row);
+    });
+  });
+});
+
+app.delete('/xp-history/:id', (req, res) => {
+  xpHistory.deleteEntry(req.params.id, err => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json({ success: true });
+  });
+});
+
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/backend/models/courseModel.js
+++ b/backend/models/courseModel.js
@@ -16,8 +16,22 @@ function listCourses(cb) {
   db.all('SELECT * FROM courses', cb);
 }
 
+function updateCourse(id, title, description, cb) {
+  const stmt = db.prepare('UPDATE courses SET title = ?, description = ? WHERE id = ?');
+  stmt.run(title, description, id, cb);
+  stmt.finalize();
+}
+
+function deleteCourse(id, cb) {
+  const stmt = db.prepare('DELETE FROM courses WHERE id = ?');
+  stmt.run(id, cb);
+  stmt.finalize();
+}
+
 module.exports = {
   createCourse,
   getCourseById,
-  listCourses
+  listCourses,
+  updateCourse,
+  deleteCourse
 };

--- a/backend/models/xpHistoryModel.js
+++ b/backend/models/xpHistoryModel.js
@@ -12,7 +12,26 @@ function getHistoryByUser(userId, cb) {
   db.all('SELECT * FROM xp_history WHERE user_id = ? ORDER BY ts DESC', [userId], cb);
 }
 
+function getEntryById(id, cb) {
+  db.get('SELECT * FROM xp_history WHERE id = ?', [id], cb);
+}
+
+function updateEntry(id, userId, courseId, xp, cb) {
+  const stmt = db.prepare('UPDATE xp_history SET user_id = ?, course_id = ?, xp = ? WHERE id = ?');
+  stmt.run(userId, courseId, xp, id, cb);
+  stmt.finalize();
+}
+
+function deleteEntry(id, cb) {
+  const stmt = db.prepare('DELETE FROM xp_history WHERE id = ?');
+  stmt.run(id, cb);
+  stmt.finalize();
+}
+
 module.exports = {
   addXP,
-  getHistoryByUser
+  getHistoryByUser,
+  getEntryById,
+  updateEntry,
+  deleteEntry
 };


### PR DESCRIPTION
## Summary
- expand course model with update and delete helpers
- expand XP history model with CRUD helpers
- expose CRUD endpoints in `backend/index.js`
- document API usage in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68535e631b94832cbd69c40db434fa72