### PR TITLE
Add pytest-based backend tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ node_modules
 package-lock.json
 
 
+
+# Python cache
+__pycache__/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -61,3 +61,12 @@ npm start        # inicia o servidor em http://localhost:3000
 ```
 
 Os modelos disponíveis são **users**, **courses** e **xp_history**. Novas entradas podem ser adicionadas via requisições HTTP ou diretamente pelo SQLite.
+
+## Testes
+
+Para rodar a suíte de testes Python, instale as dependências e execute o `pytest` na raiz do projeto:
+
+```bash
+pip install -r requirements.txt
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask
 Werkzeug
+pytest

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_home_page(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    assert b'Repositor de Hortifr' in response.data
+
+def test_treinamento_requires_login(client):
+    response = client.get('/treinamento.html', follow_redirects=False)
+    assert response.status_code in (301, 302)
+    assert '/login' in response.headers.get('Location', '')


### PR DESCRIPTION
## Summary
- add pytest suite covering Flask routes
- document how to run tests
- include pytest in requirements
- ignore Python cache

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535e640d68832cb928641e7a430e51