### PR TITLE
Enable supabase via dotenv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,8 @@ users.json
 # Backend dependencies
 backend/node_modules/
 backend/database.sqlite
+backend/.env
+.env
 
 # Node dependencies
 node_modules

--- a/README.md
+++ b/README.md
@@ -51,14 +51,21 @@ que sirva arquivos HTML, como GitHub Pages ou um servidor HTTP simples.
 
 ## Backend e Banco de Dados
 
-A pasta `backend/` contém uma API em Node.js que agora usa o [Supabase](https://supabase.com/) para armazenamento de dados. Crie um projeto no Supabase e defina as variáveis de ambiente `SUPABASE_URL` e `SUPABASE_KEY` antes de iniciar o servidor:
+A pasta `backend/` contém uma API em Node.js que agora usa o [Supabase](https://supabase.com/) para armazenamento de dados. Crie um projeto no Supabase e defina as variáveis de ambiente `SUPABASE_URL` e `SUPABASE_KEY` antes de iniciar o servidor. Você pode criar um arquivo `.env` (baseado em `.env.example`) dentro da pasta `backend/` com esses valores:
 
 ```bash
 cd backend
 npm install
-export SUPABASE_URL=https://<sua-instancia>.supabase.co
-export SUPABASE_KEY=<chave-api>
+# copie .env.example para .env e edite com suas credenciais
+cp .env.example .env
 npm start        # inicia o servidor em http://localhost:3000
+```
+
+Exemplo de `.env`:
+
+```bash
+SUPABASE_URL=https://hovuxwfziehqsbclyvoh.supabase.co
+SUPABASE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhvdnV4d2Z6aWVocXNiY2x5dm9oIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTAzMDMwMzcsImV4cCI6MjA2NTg3OTAzN30.B9H06zOdiVGcE1W72HoPnu92fojlcOXOnkvHeviq0Fw
 ```
 
 Os modelos disponíveis são **users**, **courses** e **xp_history**. As operações CRUD são executadas nas tabelas do projeto Supabase.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_KEY=your-anon-key

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^5.1.0",
-    "@supabase/supabase-js": "^2.50.0"
+    "@supabase/supabase-js": "^2.50.0",
+    "dotenv": "^16.4.5"
   }
 }

--- a/backend/supabaseClient.js
+++ b/backend/supabaseClient.js
@@ -1,4 +1,5 @@
 const { createClient } = require('@supabase/supabase-js');
+require('dotenv').config();
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_KEY;


### PR DESCRIPTION
## Summary
- allow backend to read environment variables from `.env`
- document how to configure and run the Node.js API with Supabase
- ignore `.env` files in git

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68538a33d550832c809a9270111b1050