### PR TITLE
Fix Vercel deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "engines": { "node": "18.x" },
   "type": "commonjs",
   "dependencies": {
     "express": "^5.1.0",

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,23 @@
   "builds": [
     { "src": "api/index.js", "use": "@vercel/node" }
   ],
+  "functions": {
+    "api/index.js": {
+      "includeFiles": [
+        "views/**",
+        "Style/**",
+        "imagens/**",
+        "*.html",
+        "components.js",
+        "menu.js",
+        "quiz_modulo1.js",
+        "treinamento.js",
+        "theme.js",
+        "xp.js",
+        "data/**"
+      ]
+    }
+  },
   "routes": [
     { "src": "/(.*)", "dest": "api/index.js" }
   ]


### PR DESCRIPTION
## Summary
- specify Node 18 runtime in `package.json`
- include static files and templates in Vercel build via `vercel.json`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853ad829960832ca16b945f6388ceae